### PR TITLE
fix: Adjust tempo for MEGALOVANIA melody

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,10 +116,10 @@
         ];
 
         const megalovaniaMelody = [
-            { note: 'D4', duration: 150 }, { note: 'D4', duration: 150 }, { note: 'D5', duration: 150 }, { note: 'A4', duration: 150 }, { note: 'G#4', duration: 150 }, { note: 'G4', duration: 150 }, { note: 'F4', duration: 150 }, { note: 'D4', duration: 150 }, { note: 'F4', duration: 150 }, { note: 'G4', duration: 150 },
-            { note: 'C4', duration: 150 }, { note: 'C4', duration: 150 }, { note: 'D5', duration: 150 }, { note: 'A4', duration: 150 }, { note: 'G#4', duration: 150 }, { note: 'G4', duration: 150 }, { note: 'F4', duration: 150 }, { note: 'D4', duration: 150 }, { note: 'F4', duration: 150 }, { note: 'G4', duration: 150 },
-            { note: 'B3', duration: 150 }, { note: 'B3', duration: 150 }, { note: 'D5', duration: 150 }, { note: 'A4', duration: 150 }, { note: 'G#4', duration: 150 }, { note: 'G4', duration: 150 }, { note: 'F4', duration: 150 }, { note: 'D4', duration: 150 }, { note: 'F4', duration: 150 }, { note: 'G4', duration: 150 },
-            { note: 'A#3', duration: 150 }, { note: 'A#3', duration: 150 }, { note: 'D5', duration: 150 }, { note: 'A4', duration: 150 }, { note: 'G#4', duration: 150 }, { note: 'G4', duration: 150 }, { note: 'F4', duration: 150 }, { note: 'D4', duration: 150 }, { note: 'F4', duration: 150 }, { note: 'G4', duration: 150 },
+            { note: 'D4', duration: 250 }, { note: 'D4', duration: 250 }, { note: 'D5', duration: 250 }, { note: 'A4', duration: 250 }, { note: 'G#4', duration: 250 }, { note: 'G4', duration: 250 }, { note: 'F4', duration: 250 }, { note: 'D4', duration: 250 }, { note: 'F4', duration: 250 }, { note: 'G4', duration: 250 },
+            { note: 'C4', duration: 250 }, { note: 'C4', duration: 250 }, { note: 'D5', duration: 250 }, { note: 'A4', duration: 250 }, { note: 'G#4', duration: 250 }, { note: 'G4', duration: 250 }, { note: 'F4', duration: 250 }, { note: 'D4', duration: 250 }, { note: 'F4', duration: 250 }, { note: 'G4', duration: 250 },
+            { note: 'B3', duration: 250 }, { note: 'B3', duration: 250 }, { note: 'D5', duration: 250 }, { note: 'A4', duration: 250 }, { note: 'G#4', duration: 250 }, { note: 'G4', duration: 250 }, { note: 'F4', duration: 250 }, { note: 'D4', duration: 250 }, { note: 'F4', duration: 250 }, { note: 'G4', duration: 250 },
+            { note: 'A#3', duration: 250 }, { note: 'A#3', duration: 250 }, { note: 'D5', duration: 250 }, { note: 'A4', duration: 250 }, { note: 'G#4', duration: 250 }, { note: 'G4', duration: 250 }, { note: 'F4', duration: 250 }, { note: 'D4', duration: 250 }, { note: 'F4', duration: 250 }, { note: 'G4', duration: 250 },
         ];
 
         const keyElements = {};


### PR DESCRIPTION
This commit slows down the playback speed of the 'MEGALOVANIA' melody. The note duration has been increased from 150ms to 250ms to make the song play at a more comfortable and recognizable tempo, as requested by the user.